### PR TITLE
Fix: infinite loop in withFilter

### DIFF
--- a/src/with-filter.ts
+++ b/src/with-filter.ts
@@ -15,7 +15,7 @@ export const withFilter = (asyncIteratorFn: () => AsyncIterator<any>, filterFn: 
           Promise.resolve(filterFn(payload.value, args, context, info)).catch(() => false),
         ]))
         .then(([payload, filterResult]) => {
-          if (filterResult === true) {
+          if (filterResult === true || payload.done === true) {
             return payload;
           }
 


### PR DESCRIPTION
https://github.com/apollographql/graphql-subscriptions/issues/81

Check for filterResult or if it `payload.done`.  Has a side effect that it `undefined` is passed to filterFn. At least it doesn't infinite loop.